### PR TITLE
When removing unused donations, remove relevant conversations as well

### DIFF
--- a/src/models/conversations.model.ts
+++ b/src/models/conversations.model.ts
@@ -1,0 +1,39 @@
+import {Document, model, Schema, Types} from 'mongoose';
+
+export interface ConversationMongooseDocument extends Document {
+  milestoneId:string,
+  donationId: string,
+  messageContext:string
+}
+const conversationSchema = new Schema(
+  {
+    milestoneId: {type: String, required: true},
+    messageContext: {type: String, required: true},
+    message: {type: String},
+    replyToId: {type: String},
+    performedByRole: {type: String, required: true},
+    ownerAddress: {type: String, required: true},
+    recipientAddress: {type: String},
+    payments: [
+      {
+        amount: {type: String},
+        symbol: {type: String},
+        tokenDecimals: {type: String},
+      },
+    ],
+    donorType: {type: String},
+    donorId: {type: String},
+
+    // this is for payment conversations
+    donationId: {type: String},
+    items: {type:Array},
+    txHash: {type: String},
+    mined: {type: Boolean, default: false},
+  },
+  {
+    timestamps: true,
+  },
+);
+
+
+export const conversationModel = model<ConversationMongooseDocument>('conversations', conversationSchema);

--- a/src/services/donationService.ts
+++ b/src/services/donationService.ts
@@ -3,6 +3,7 @@ import BigNumber from "bignumber.js";
 import {DonationObjectInterface, ExtendedDonation, PledgeInterface, ReportInterface} from "../utils/interfaces";
 import {getTokenByAddress, getTokenCutoff} from "../utils/tokenUtility";
 import {getLogger} from "../utils/logger";
+import {conversationModel} from "../models/conversations.model";
 
 const logger = getLogger();
 
@@ -127,7 +128,6 @@ export async function fixConflictInDonations(
           `Donation was unused!\n${JSON.stringify(
             {
               _id,
-              _idType:typeof _id,
               amount: amount.toString(),
               amountRemaining,
               status,
@@ -140,9 +140,12 @@ export async function fixConflictInDonations(
           )}`,
         );
         if (fixConflicts) {
-          logger.debug('Deleting...');
+          logger.info('Deleting conversation and relevant conversation if exists ...', {_id});
           report.deletedDonations ++;
           promises.push(donationModel.findOneAndDelete({_id}));
+          promises.push(conversationModel.findOneAndDelete({
+            donationId:_id,
+          }));
 
         }
       } else {


### PR DESCRIPTION
related to #26

I added a fake donation manually for beow milestone, then I added a fake conversation with a field named `donationId` and value of that fake `donation._id` then I ran simulation script and fake donation and it's relevant conversation have been deleted.

![image](https://user-images.githubusercontent.com/9850545/108251806-228d6d80-716d-11eb-9b66-378feb0ffba5.png)

![image](https://user-images.githubusercontent.com/9850545/108252042-6bddbd00-716d-11eb-99a2-f5ae2f891e6f.png)

