### PR TITLE
Dont change status of ToApprove donations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -274,13 +274,6 @@ const handleFromDonations = async (from: string, to: string,
           fromAmount = fromAmount.minus(min);
           if (new BigNumber(item.amountRemaining).isZero()) {
             consumedCandidates += 1;
-            // It's approve or reject
-            if (item.status === DonationStatus.TO_APPROVE) {
-              item.status =
-                Number(toPledge.owner) === item.intendedProjectId
-                  ? DonationStatus.COMMITTED
-                  : DonationStatus.REJECTED;
-            }
           }
           logger.debug(
             `Amount ${min.toFixed()} is reduced from ${JSON.stringify(


### PR DESCRIPTION
related to Giveth/giveth-dapp#2022

Simulation should not change `ToApprove` donations status. giveth-feathers should normalizePledge after 3 days of donation commitTime (if donations is still ToApprove)